### PR TITLE
fixed tags and multiplayer filter

### DIFF
--- a/classes/mainUserClass.py
+++ b/classes/mainUserClass.py
@@ -89,7 +89,7 @@ class MainUser(User):
           tags_table = entry.find('p', class_='tags')
           tag_spans = tags_table.find_all('span') if tags_table else []
           for tag in tag_spans:
-            game_tag_list.append(tag.get_text(strip=True))
+            game_tag_list.append((tag.get_text(strip=True)).replace(",", ""))    # added stripping the coma
 
           hours_tag = entry.find('p', class_='hours')
           hours = 0.0   # default value so missing it doesn't crash    

--- a/classes/utilityClass.py
+++ b/classes/utilityClass.py
@@ -1,6 +1,6 @@
 from classes.userClass import User
 from classes.gameClass import Game
-from constants import STEAM_ID_LINK, STEAM_PROFILE_SIGNATURE_IMG_LINK, STEAM_PROFILE_URL_FOR_PARSE
+from constants import STEAM_ID_LINK, STEAM_PROFILE_SIGNATURE_IMG_LINK, STEAM_PROFILE_URL_FOR_PARSE, MULTIPLAYER_TAGS
 import random
 import requests
 from bs4 import BeautifulSoup
@@ -29,7 +29,8 @@ class Utility:
                 raise TypeError(f"All elements in 'selected_friends' in Utility.find_common_games must be instances of the User class. "
                                 f"Found non-User element at index {i}: {type(friend)}")
         selected_friends = Utility.create_full_users_from_list(selected_friends)
-        games_shared_with_friends = set(main_user.game_list) # It's more efficient keeping it as set for the whole loop duration
+        main_user_mp_games = Utility.reduce_games_list_from_any_tags(MULTIPLAYER_TAGS, main_user.game_list)
+        games_shared_with_friends = set(main_user_mp_games) # It's more efficient keeping it as set for the whole loop duration
         for x in range(0, len(selected_friends)):
             if selected_friends[x].is_account_private or len(selected_friends[x].game_list) == 0:
                 continue
@@ -40,7 +41,7 @@ class Utility:
         return list(games_shared_with_friends) # Don't forget to prepare for empty list scenario when using this method
         
     @staticmethod
-    def reduce_games_list_from_tags(filtering_tags: list[str], list_of_games: list[Game]) -> list[Game]:
+    def reduce_games_list_from_tags(filtering_tags: list[str], list_of_games: list[Game]) -> list[Game]: # hard filter
         """
         Filters a list of Game objects, returning a new list containing only unique games that possess ALL of the specified filtering tags.
         """
@@ -65,6 +66,35 @@ class Utility:
             if all(tag in game.tags for tag in filtering_tags):
                 if game not in reduced_list:
                     reduced_list.append(game)
+        return reduced_list
+    
+    @staticmethod
+    def reduce_games_list_from_any_tags(filtering_tags: list[str], list_of_games: list[Game]) -> list[Game]:    # soft filter
+        """
+        Filters a list of Game objects, returning a new list containing only unique games that possess ANY of the specified filtering tags.
+        """
+        if not isinstance(list_of_games, list):
+            raise TypeError("Input 'list_of_games' in Utility.reduce_games_list_from_tags must be a list.")
+        if not list_of_games:
+            raise ValueError("The 'list_of_games' is empty.")
+        for i, game in enumerate(list_of_games):
+            if not isinstance(game, Game):
+                raise TypeError(f"All elements in 'list_of_games' in Utility.reduce_games_list_from_tags must be instances of the Game class. "
+                                f"Found non-Game element at index {i}: {type(game)}")
+        if not isinstance(filtering_tags, list):
+            raise TypeError("Input 'filtering_tags' in Utility.reduce_games_list_from_tags must be a list.")        
+        if not filtering_tags:
+            return list_of_games
+        for i, tag in enumerate(filtering_tags):
+            if not isinstance(tag, str):
+                raise TypeError(f"All elements in 'filtering_tags' in Utility.reduce_games_list_from_tags must be strings. "
+                                f"Found non-string element at index {i}: {type(tag)}")
+        reduced_list = []
+        for game in list_of_games:
+            for tag in filtering_tags:
+                if tag in game.tags:
+                    if game not in reduced_list:
+                        reduced_list.append(game)
         return reduced_list
 
     @staticmethod

--- a/constants.py
+++ b/constants.py
@@ -12,10 +12,13 @@ STEAM_PROFILE_URL_FOR_PARSE = "https://steamcommunity.com/profiles/"
 
 STEAM_ID_URL = "https://steamcommunity.com/profiles/"
 
-
+# MAIN USER
 WEBPAGE_WAIT_TIME = 15
 
+# UTILITY
+MULTIPLAYER_TAGS = ["Co-op", "Co-op Campaign", "Local Co-Op", "Online Co-Op", "Asynchronous Multiplayer", "Local Multiplayer", "Massively Multiplayer", "Multiplayer"]
 
+# BATCH
 UPPER_LIMIT = 200
 LOWER_LIMIT = 100
 
@@ -24,8 +27,7 @@ LOWER_MAX_BATCH = 10
 
 SCALING_FACTOR = 10
 
-MIN_BATCH = 3 #probably not needed anymore, unless we want to implement like a last pick scenario
-
+# WINDOW AND COLORS
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 500
 BORDER_WIDTH = 5


### PR DESCRIPTION
fixed tags, added new soft filter method, hooked it to find_common_games to filter through multiplayer-like tags
this solves the following issues:
<https://github.com/Team-MEA/SteamGamesPicker/issues/32>
<https://github.com/Team-MEA/SteamGamesPicker/issues/31>
